### PR TITLE
🐛 Fix update env

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kinto
 home: https://www.kintohub.com/
-version: 0.2.1
+version: 0.2.2
 description: All-in-one deployment platform designed for fullstack developers
 dependencies:
 - name: nginx-ingress-controller

--- a/templates/core-cluster-role.yaml
+++ b/templates/core-cluster-role.yaml
@@ -26,6 +26,7 @@ rules:
   - namespaces
   verbs:
   - create
+  - update
   - get
   - delete
   - list


### PR DESCRIPTION
- kinto core was missing a namespace update rule
- bump up the chart version to 0.2.2