### PR TITLE
🚧 Add default empty dir on workflow

### DIFF
--- a/charts/kinto/Chart.yaml
+++ b/charts/kinto/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kinto
 home: https://www.kintohub.com/
-version: 0.4.3
+version: 0.4.4
 description: All-in-one deployment platform designed for fullstack developers
 dependencies:
 - name: nginx-ingress-controller

--- a/charts/kinto/values.yaml
+++ b/charts/kinto/values.yaml
@@ -80,7 +80,7 @@ builder:
     ARGO_WORKFLOW_TTL_SECONDS: 120  ## After completion, Argo automatically clean up kubernetes and delete the workflow after ARGO_WORKFLOW_TTL_SECONDS in seconds
     ARGO_WORKFLOW_MINIO_BUCKET: argo-artifacts
     ARGO_WORKFLOW_IMAGE_PULL_POLICY: IfNotPresent
-    ARGO_WORKFLOW_VOLUME_SIZE:  ## each workflow can use a private volume.
+    ARGO_WORKFLOW_VOLUME_SIZE: 1Gi  ## each workflow can use an empty dir volume -> https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
     ARGO_WORKFLOW_MEMORY_LIMIT:
     ARGO_WORKFLOW_CPU_LIMIT:
     ARGO_WORKFLOW_MEMORY_REQUEST:


### PR DESCRIPTION
A user mentioned his workflow was not building because by default we don't use an empty dir volume on the workflows.